### PR TITLE
Print HTTP messages to string directly

### DIFF
--- a/theories/Message.v
+++ b/theories/Message.v
@@ -28,7 +28,7 @@ Record authority :=
   Authority {
       authority__userinfo : option string;
       authority__host     : string;
-      authroity__port     : option N
+      authority__port     : option N
     }.
 
 (** https://www.rfc-editor.org/rfc/rfc3986.html#section-3.3 *)
@@ -141,10 +141,11 @@ Record http_request :=
       request__body   : option message_body
     }.
 
-Record http_response exp_ :=
+Record http_response {exp_} :=
   Response {
       response__line   : status_line;
       response__fields : list (field_line exp_);
       response__body   : option (exp_ message_body)
     }.
-Arguments Response {_}.
+Arguments http_response : clear implicits.
+Arguments Response {exp_}.

--- a/theories/Printer.v
+++ b/theories/Printer.v
@@ -1,101 +1,112 @@
 From Coq Require Export
-     Ascii.
-From Ceres Require Export
-     Ceres.
+     Ascii
+     NArith
+     String
+     DecimalString.
 From ExtLib Require Export
      Extras.
 From HTTP Require Export
      Message.
 Export FunNotation.
 
-Instance Serialize__method : Serialize request_method :=
-  fun m => Atom (match m with
-              | Method__GET     => "GET"
-              | Method__HEAD    => "HEAD"
-              | Method__POST    => "POST"
-              | Method__PUT     => "PUT"
-              | Method__DELETE  => "DELETE"
-              | Method__CONNECT => "CONNECT"
-              | Method__OPTIONS => "OPTIONS"
-              | Method__TRACE   => "TRACE"
-              | Method s      => s
-              end).
+Definition N_to_string (n : N) : string :=
+  NilZero.string_of_uint (N.to_uint n).
 
-Instance Serialize__scheme : Serialize http_scheme :=
-  fun s => Atom (match s with
-              | Scheme__HTTP  => "http://"
-              | Scheme__HTTPS => "https://"
-              end).
+Definition method_to_string (m : request_method) : string :=
+  match m with
+  | Method__GET     => "GET"
+  | Method__HEAD    => "HEAD"
+  | Method__POST    => "POST"
+  | Method__PUT     => "PUT"
+  | Method__DELETE  => "DELETE"
+  | Method__CONNECT => "CONNECT"
+  | Method__OPTIONS => "OPTIONS"
+  | Method__TRACE   => "TRACE"
+  | Method s      => s
+  end.
 
-Instance Serialize__authority : Serialize authority :=
-  fun s =>
-    let 'Authority ou h op := s in
-    Atom ((match ou with
-           | Some u => u ++ "@"
-           | None   => ""
-           end) ++ h ++
-          (match op with
-           | Some p => String ":" $ to_string p
-           | None   => ""
-           end)).
+Definition scheme_to_string (s : http_scheme) : string :=
+  match s with
+  | Scheme__HTTP  => "http://"
+  | Scheme__HTTPS => "https://"
+  end.
 
-Instance Serialize__path : Serialize path :=
-  fun p => Atom (String "/" $ concat "/" p).
+(* ["user"] to ["user@"] *)
+Definition userinfo_to_string (ou : option string) : string :=
+  match ou with
+  | Some u => u ++ "@"
+  | None   => ""
+  end.
 
-Instance Serialize__oquery : Serialize (option query) :=
-  fun oq => Atom (match oq with
-               | Some q => String "?" q
-               | None   => ""
-               end).
+(* ["80"] to [":80"] *)
+Definition port_to_string (p : option N) : string :=
+  match p with
+  | Some p => String ":" (N_to_string p)
+  | None => ""
+  end.
 
-Instance Serialize__target : Serialize request_target :=
-  fun t => Atom (match t with
-              | RequestTarget__Origin p oq => to_string p ++ to_string oq
-              | RequestTarget__Absolute s a p oq =>
-                to_string s ++ to_string a ++ to_string p ++ to_string oq
-              | RequestTarget__Authority a => to_string a
-              | RequestTarget__Asterisk => "*"
-              end).
+Definition authority_to_string (s : authority) : string :=
+  userinfo_to_string (authority__userinfo s) ++
+  authority__host s ++
+  port_to_string (authority__port s).
 
-Instance Serialize__version : Serialize http_version :=
-  fun v =>
-    let 'Version m n := v in
-    Atom ("HTTP/" ++ to_string m ++ String "." (to_string n)).
+Definition path_to_string (p : path) : string :=
+  String "/" (String.concat "/" p).
 
-Instance Serialize__line : Serialize request_line :=
-  fun l =>
-    let 'RequestLine m t v := l in
-    Atom (to_string m ++ String " " (to_string t) ++ String " " (to_string v)).
+Definition oquery_to_string (oq : option query) : string :=
+  match oq with
+  | Some q => String "?" q
+  | None   => ""
+  end.
 
-Instance Serialize__status : Serialize status_line :=
-  fun l =>
-    let 'Status v c op := l in
-    Atom (to_string v ++ String " " (to_string c) ++ String " " (match op with
-                                                                 | Some p => p
-                                                                 | None   => ""
-                                                                 end)).
+Definition target_to_string (t : request_target) : string :=
+  match t with
+  | RequestTarget__Origin p oq => path_to_string p ++ oquery_to_string oq
+  | RequestTarget__Absolute s a p oq =>
+    scheme_to_string s ++ authority_to_string a ++ path_to_string p ++ oquery_to_string oq
+  | RequestTarget__Authority a => authority_to_string a
+  | RequestTarget__Asterisk => "*"
+  end.
 
-Instance Serialize__field : Serialize (field_line id) :=
-  fun f => let 'Field n v := f in Atom (n ++ ": " ++ v).
+Definition version_to_string (v : http_version) : string :=
+  "HTTP/" ++ N_to_string (version__major v) ++ String "." (N_to_string (version__minor v)).
+
+Definition line_to_string (l : request_line) : string :=
+  method_to_string (request__method l) ++ String " " (
+  target_to_string (request__target l) ++ String " " (
+  version_to_string (request__version l))).
+
+Definition status_to_string (l : status_line) : string :=
+  version_to_string (status__version l) ++ String " " (
+  N_to_string (status__code l) ++ String " " (
+  match status__phrase l with
+  | Some p => p
+  | None   => ""
+  end)).
+
+Definition field_to_string (f : field_line id) : string :=
+  let 'Field n v := f in n ++ ": " ++ v.
 
 Definition CRLF : string := String "013" (String "010" "").
 
-Instance Serialize__fields : Serialize (list (field_line id)) :=
-  fun l => Atom (concat CRLF (map to_string l)).
+Definition fields_to_string (l : list (field_line id)) : string :=
+  String.concat CRLF (map field_to_string l).
 
-Instance Serialize__body : Serialize (option message_body) :=
-  fun ob => Atom (match ob with
-               | Some b => b
-               | None   => ""
-               end).
+Definition body_to_string (ob : option message_body) : string :=
+  match ob with
+  | Some b => b
+  | None   => ""
+  end.
 
-Instance Serialize__request : Serialize http_request :=
-  fun r =>
-    let 'Request l fs ob := r in
-    Atom (to_string l ++ CRLF ++ to_string fs ++ CRLF ++ CRLF ++ to_string ob).
+Definition request_to_string (r : http_request) : string :=
+  let 'Request l fs ob := r in
+  line_to_string (request__line r) ++ CRLF ++
+  fields_to_string (request__fields r) ++ CRLF ++
+  CRLF ++
+  body_to_string (request__body r).
 
-Instance Serialize__response : Serialize (http_response id) :=
-  fun r =>
-    let 'Response l fs ob' := r in
-    let ob : option message_body := ob' in
-    Atom (to_string l ++ CRLF ++ to_string fs ++ CRLF ++ CRLF ++ to_string ob).
+Definition response_to_string (r : http_response id) : string :=
+  status_to_string (response__line r) ++ CRLF ++
+  fields_to_string (response__fields r) ++ CRLF ++
+  CRLF ++
+  body_to_string (response__body r).

--- a/theories/Semantics.v
+++ b/theories/Semantics.v
@@ -2,8 +2,6 @@ From Coq Require Export
      Basics
      Bool
      DecidableClass.
-From Ceres Require Import
-     CeresString.
 From Ceres Require Export
      Ceres.
 From ExtLib Require Export


### PR DESCRIPTION
Fixes #1

This reduces the dependency on ceres, there is just one `Decidable string` instance from it still being used, that should really go in the stdlib (we should really create a `coq-string-compat` library to not have to wait for the next version of Coq).